### PR TITLE
Use __dirname to navigate to explicitly navigate to nsolid files

### DIFF
--- a/bin/nsolid-manager.js
+++ b/bin/nsolid-manager.js
@@ -41,11 +41,11 @@ var etcdArgs = ['-name', 'nsolid_proxy', '-listen-client-urls', 'http://0.0.0.0:
 
 // TODO: Allow the location of the proxy files to be specified?
 var proxyExec = 'node';
-var proxyArgs = ['nsolid/proxy/proxy.js'];
+var proxyArgs = [__dirname + '/../nsolid/proxy/proxy.js'];
 
 // TODO: Allow the location of the console files to be specified?
 var consoleExec = 'node';
-var consoleArgs = ['nsolid/console/bin/nsolid-console', '--interval=1000'];
+var consoleArgs = [__dirname + '/../nsolid/console/bin/nsolid-console', '--interval=1000'];
 
 // Start up target app with nsolid
 var appExec = 'nsolid';

--- a/src/bin/nsolid-manager.js
+++ b/src/bin/nsolid-manager.js
@@ -42,11 +42,11 @@ const etcdArgs = ['-name', 'nsolid_proxy', '-listen-client-urls', 'http://0.0.0.
 
 // TODO: Allow the location of the proxy files to be specified?
 const proxyExec = 'node';
-const proxyArgs = ['nsolid/proxy/proxy.js'];
+const proxyArgs = [`${__dirname}/../nsolid/proxy/proxy.js`];
 
 // TODO: Allow the location of the console files to be specified?
 const consoleExec = 'node';
-const consoleArgs = ['nsolid/console/bin/nsolid-console', '--interval=1000'];
+const consoleArgs = [`${__dirname}/../nsolid/console/bin/nsolid-console`, '--interval=1000'];
 
 // Start up target app with nsolid
 const appExec = 'nsolid';


### PR DESCRIPTION
This still doesn't solve the .nsolid-proxyrc issue called out in Issue #6, but it fixes a separate one where it couldn't find the nsolid files if you weren't in the right execution context.
