### PR TITLE
Silo environment vars

### DIFF
--- a/bin/nsolid-manager.js
+++ b/bin/nsolid-manager.js
@@ -24,11 +24,11 @@ var etcdExec = 'etcd';
 var etcdArgs = ['-name', 'nsolid_proxy', '-listen-client-urls', 'http://0.0.0.0:4001', '-advertise-client-urls', 'http://0.0.0.0:4001', '-initial-cluster-state', 'new'];
 
 // TODO: Allow the location of the proxy files to be specified?
-var proxyExec = 'node';
+var proxyExec = 'nsolid';
 var proxyArgs = [path.resolve(__dirname, '../nsolid/proxy/proxy.js')];
 
 // TODO: Allow the location of the console files to be specified?
-var consoleExec = 'node';
+var consoleExec = 'nsolid';
 var consoleArgs = [path.resolve(__dirname, '../nsolid/console/bin/nsolid-console'), '--interval=1000'];
 
 // Start up target app with nsolid

--- a/bin/nsolid-manager.js
+++ b/bin/nsolid-manager.js
@@ -24,13 +24,8 @@ var etcdExec = 'etcd';
 var etcdArgs = ['-name', 'nsolid_proxy', '-listen-client-urls', 'http://0.0.0.0:4001', '-advertise-client-urls', 'http://0.0.0.0:4001', '-initial-cluster-state', 'new'];
 
 // TODO: Allow the location of the proxy files to be specified?
-<<<<<<< HEAD
 var proxyExec = 'nsolid';
-var proxyArgs = [path.resolve(__dirname, '../nsolid/proxy/proxy.js')];
-=======
-var proxyExec = 'node';
 var proxyArgs = [path.resolve(__dirname, '../nsolid/proxy/proxy.js'), '--config', path.resolve(__dirname, '../nsolid/proxy/.nsolid-proxyrc')];
->>>>>>> 29fc741d3b173fc84f14411c8f1eb49feda4b509
 
 // TODO: Allow the location of the console files to be specified?
 var consoleExec = 'nsolid';

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Sean O'Hollaren",
   "license": "ISC",
   "dependencies": {
+    "extend": "^3.0.0",
     "minimist": "^1.2.0"
   },
   "devDependencies": {

--- a/src/bin/nsolid-manager.js
+++ b/src/bin/nsolid-manager.js
@@ -23,11 +23,11 @@ const etcdExec = 'etcd';
 const etcdArgs = ['-name', 'nsolid_proxy', '-listen-client-urls', 'http://0.0.0.0:4001', '-advertise-client-urls', 'http://0.0.0.0:4001', '-initial-cluster-state', 'new'];
 
 // TODO: Allow the location of the proxy files to be specified?
-const proxyExec = 'node';
+const proxyExec = 'nsolid';
 const proxyArgs = [path.resolve(__dirname, '../nsolid/proxy/proxy.js')];
 
 // TODO: Allow the location of the console files to be specified?
-const consoleExec = 'node';
+const consoleExec = 'nsolid';
 const consoleArgs = [path.resolve(__dirname, '../nsolid/console/bin/nsolid-console'), '--interval=1000'];
 
 // Start up target app with nsolid


### PR DESCRIPTION
Target app's child process now has environment variables explicitly passed in.

Added a function which retrieves the current environment variables and adds our custom nsolid ones, then passes back the result.

Proxy and Console are now started with nsolid.
